### PR TITLE
Fix some Galaxy references & metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](https://github.com/octo-technology/keycloak-collection/workflows/ansible-test/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/octo-technology/keycloak-collection/branch/master/graph/badge.svg)](https://codecov.io/gh/octo-technology/keycloak-collection)
 
-This repo hosts the `inspq.keycloak` Ansible Collection.
+This repo hosts the `elfelip.keycloak` Ansible Collection.
 
 The collection includes a variety of Ansible content to help automate the management of resources in Keycloak.
 
@@ -37,13 +37,13 @@ This collection is currently testing the modules against Keycloak versions `8.0.
 
 Before using the Keycloak collection, you need to install it with the Ansible Galaxy CLI:
 
-    ansible-galaxy collection install <collection_archive_path>
+    ansible-galaxy collection install elfelip.keycloak
 
 The archive can be downloaded from the Github release page.
 
 ### Using modules from the Keycloak Collection in your playbooks
 
-You can either call modules by their Fully Qualified Collection Namespace (FQCN), like `inspq.keycloak.keycloak_client`, or you can call modules by their short name if you list the `inspq.keycloak` collection in the playbook's `collections`, like so:
+You can either call modules by their Fully Qualified Collection Namespace (FQCN), like `elfelip.keycloak.keycloak_client`, or you can call modules by their short name if you list the `elfelip.keycloak` collection in the playbook's `collections`, like so:
 
 ```yaml
 ---
@@ -52,7 +52,7 @@ You can either call modules by their Fully Qualified Collection Namespace (FQCN)
   connection: local
 
   collections:
-    - inspq.keycloak
+    - elfelip.keycloak
 
   tasks:
     - name: Create or update Keycloak client (minimal example)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -46,13 +46,13 @@ tags: ["keycloak", "identity"]
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: http://example.com/repository
+repository: https://github.com/elfelip/keycloak
 
 # The URL to any online docs
-documentation: http://docs.example.com
+documentation: https://github.com/elfelip/keycloak#readme
 
 # The URL to the homepage of the collection/project
-homepage: http://example.com
+homepage: https://github.com/elfelip/keycloak
 
 # The URL to the collection issue tracker
-issues: http://example.com/issue/tracker
+issues: https://github.com/elfelip/keycloak/issues


### PR DESCRIPTION
It would be nice to understand which repo belongs to Galaxy Ansible module [_elfelip.keycloak_](https://galaxy.ansible.com/elfelip/keycloak).